### PR TITLE
LLS: Add LiveLockScreenSettings to ENTRY_FRAGMENTS

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -83,6 +83,7 @@ import com.android.settings.blacklist.BlacklistSettings;
 import com.android.settings.bluetooth.BluetoothSettings;
 import com.android.settings.contributors.ContributorsCloudFragment;
 import com.android.settings.cyanogenmod.DisplayRotation;
+import com.android.settings.cyanogenmod.LiveLockScreenSettings;
 import com.android.settings.dashboard.DashboardCategory;
 import com.android.settings.dashboard.DashboardSummary;
 import com.android.settings.dashboard.DashboardTile;
@@ -375,7 +376,8 @@ public class SettingsActivity extends Activity
             BlacklistSettings.class.getName(),
             ProfilesSettings.class.getName(),
             ContributorsCloudFragment.class.getName(),
-            NotificationManagerSettings.class.getName()
+            NotificationManagerSettings.class.getName(),
+            LiveLockScreenSettings.class.getName()
     };
 
 


### PR DESCRIPTION
Trying to launch Live lock screen settings will throw an
IllegalArgumentException since the fragment is not considered
valid.  Add it to ENTRY_FRAGMENTS so it is considered valid.

Change-Id: I13b52dc2f65f62fe7146b3002720a901dd363338
