### PR TITLE
Add the ability to hide superuser status bar icon [2/2]

### DIFF
--- a/res/values/vu_strings.xml
+++ b/res/values/vu_strings.xml
@@ -47,5 +47,9 @@
     <string name="status_bar_vu_logo_summary_on">VanillaUnicorn logo is active</string>
     <string name="status_bar_vu_logo_summary_off">Toggle to show VanillaUnicorn logo on statusbar</string>
 
+<!-- Superuser indicator on status bar -->
+    <string name="su_indicator">Superuser indicator</string>
+    <string name="su_indicator_summary_on">Superuser indicator is visible when a session is active</string>
+    <string name="su_indicator_summary_off">Toggle to show superuser indicator when a session is active</string>
 
 </resources>

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -70,6 +70,13 @@
         android:summaryOff="@string/status_bar_vu_logo_summary_off"
         android:defaultValue="false" />
 
+    <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+        android:key="show_su_indicator"
+        android:title="@string/su_indicator"
+        android:summaryOn="@string/su_indicator_summary_on"
+        android:summaryOff="@string/su_indicator_summary_off"
+        android:defaultValue="true" />
+
     <com.android.settings.cyanogenmod.CMSystemSettingSwitchPreference
         android:key="status_bar_notif_count"
         android:title="@string/status_bar_notif_count_title"
@@ -125,7 +132,5 @@
              android:persistent="false" />
 
      </PreferenceCategory>
-
- 
 
 </PreferenceScreen>


### PR DESCRIPTION
- Add a simple option to hide the su icon placed in status bar when a session is active

forward ported from crDroid sources: https://github.com/crdroidandroid/android_packages_apps_Settings/commit/9e03e5d36e89bbc48d32c8bce59ac8c172a0e47e
Edited for VanillaUnicorn

Change-Id: I2da70a5b8dd94791f289504164d8e38326e71c6d

Conflicts:
    res/values/cr_strings.xml
    res/xml/status_bar_settings.xml
