### PR TITLE
Settings: add back status bar date & style options (2/2)

### DIFF
--- a/res/values/vu_arrays.xml
+++ b/res/values/vu_arrays.xml
@@ -92,4 +92,51 @@
          <item>4</item>
       </string-array>
 
+     <!-- Statusbar date -->
+     <string-array name="status_bar_date_entries">
+         <item>@string/status_bar_date_none</item>
+         <item>@string/status_bar_date_small</item>
+         <item>@string/status_bar_date_normal</item>
+     </string-array>
+ 
+     <string-array name="status_bar_date_values" translatable="false">
+         <item>0</item>
+         <item>1</item>
+         <item>2</item>
+     </string-array>
+ 
+     <string-array name="status_bar_date_style_entries">
+         <item>@string/status_bar_date_style_normal</item>
+         <item>@string/status_bar_date_style_lowercase</item>
+         <item>@string/status_bar_date_style_uppercase</item>
+     </string-array>
+ 
+     <string-array name="status_bar_date_style_values" translatable="false">
+         <item>0</item>
+         <item>1</item>
+         <item>2</item>
+     </string-array>
+ 
+     <string-array name="status_bar_date_format_entries_values">
+         <item>dd/MM/yy</item>
+         <item>MM/dd/yy</item>
+         <item>yyyy-MM-dd</item>
+         <item>yyyy-dd-MM</item>
+         <item>dd-MM-yyyy</item>
+         <item>MM-dd-yyyy</item>
+         <item>MMM dd</item>
+         <item>MMM dd, yyyy</item>
+         <item>MMMM dd, yyyy</item>
+         <item>EEE</item>
+         <item>EEE dd</item>
+         <item>EEE dd/MM</item>
+         <item>EEE MM/dd</item>
+         <item>EEE dd MMM</item>
+         <item>EEE MMM dd</item>
+         <item>EEE MMMM dd</item>
+         <item>EEEE dd/MM</item>
+         <item>EEEE MM/dd</item>
+         <item>@string/status_bar_date_format_custom</item>
+     </string-array>
+
 </resources>

--- a/res/values/vu_strings.xml
+++ b/res/values/vu_strings.xml
@@ -70,4 +70,19 @@
     <string name="battery_bar_animate_title">Charging animation</string>
     <string name="battery_bar_animate_summary">The charging animation may slow down the UI. Enable at your own discretion.</string>
 
+  <!--Status bar date -->
+    <string name="status_bar_clock_category">Clock</string>
+    <string name="status_bar_date_title">Date</string>
+    <string name="status_bar_date_none">Hidden (default)</string>
+    <string name="status_bar_date_small">Small</string>
+    <string name="status_bar_date_normal">Normal</string>
+    <string name="status_bar_date_format_title">Date format</string>
+    <string name="status_bar_date_style">Date style</string>
+    <string name="status_bar_date_style_normal">Normal</string>
+    <string name="status_bar_date_style_lowercase">Lowercase</string>
+    <string name="status_bar_date_style_uppercase">Uppercase</string>
+    <string name="status_bar_date_format_custom">Custom java format</string>
+    <string name="status_bar_date_string_edittext_title">Must be in DateFormat eg. MM/dd/yy</string>
+    <string name="status_bar_date_string_edittext_summary">Enter string</string>
+
 </resources>

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -44,6 +44,27 @@
         android:entryValues="@array/status_bar_am_pm_values" />
 
     <ListPreference
+        android:key="status_bar_date"
+        android:title="@string/status_bar_date_title"
+        android:dialogTitle="@string/status_bar_date_title"
+        android:entries="@array/status_bar_date_entries"
+        android:entryValues="@array/status_bar_date_values" />
+
+    <ListPreference
+        android:key="status_bar_date_style"
+        android:title="@string/status_bar_date_style"
+        android:dialogTitle="@string/status_bar_date_style"
+        android:entries="@array/status_bar_date_style_entries"
+        android:entryValues="@array/status_bar_date_style_values" />
+
+    <ListPreference
+        android:key="status_bar_date_format"
+        android:title="@string/status_bar_date_format_title"
+        android:dialogTitle="@string/status_bar_date_format_title"
+        android:entries="@array/status_bar_date_format_entries_values"
+        android:entryValues="@array/status_bar_date_format_entries_values" />
+
+    <ListPreference
         android:key="status_bar_battery_style"
         android:title="@string/status_bar_battery_style_title"
         android:dialogTitle="@string/status_bar_battery_style_title"

--- a/src/com/android/settings/cyanogenmod/StatusBarSettings.java
+++ b/src/com/android/settings/cyanogenmod/StatusBarSettings.java
@@ -15,8 +15,12 @@
  */
 package com.android.settings.cyanogenmod;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -32,6 +36,7 @@ import android.provider.Settings;
 import android.telephony.TelephonyManager;
 import android.text.format.DateFormat;
 import android.view.View;
+import android.widget.EditText;
 
 import com.android.internal.logging.MetricsLogger;
 import com.android.settings.R;
@@ -42,6 +47,7 @@ import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.search.Indexable;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +60,9 @@ public class StatusBarSettings extends SettingsPreferenceFragment
 
     private static final String STATUS_BAR_CLOCK_STYLE = "status_bar_clock";
     private static final String STATUS_BAR_AM_PM = "status_bar_am_pm";
+    private static final String STATUS_BAR_DATE = "status_bar_date";
+    private static final String STATUS_BAR_DATE_STYLE = "status_bar_date_style";
+    private static final String STATUS_BAR_DATE_FORMAT = "status_bar_date_format";
     private static final String STATUS_BAR_BATTERY_STYLE = "status_bar_battery_style";
     private static final String STATUS_BAR_SHOW_BATTERY_PERCENT = "status_bar_show_battery_percent";
     private static final String NETWORK_TRAFFIC_STATE = "network_traffic_state";
@@ -66,8 +75,15 @@ public class StatusBarSettings extends SettingsPreferenceFragment
     private static final int STATUS_BAR_BATTERY_STYLE_HIDDEN = 4;
     private static final int STATUS_BAR_BATTERY_STYLE_TEXT = 6;
 
+    public static final int CLOCK_DATE_STYLE_LOWERCASE = 1;
+    public static final int CLOCK_DATE_STYLE_UPPERCASE = 2;
+    private static final int CUSTOM_CLOCK_DATE_FORMAT_INDEX = 18;
+
     private ListPreference mStatusBarClock;
     private ListPreference mStatusBarAmPm;
+    private ListPreference mStatusBarDate;
+    private ListPreference mStatusBarDateStyle;
+    private ListPreference mStatusBarDateFormat;
     private ListPreference mStatusBarBattery;
     private ListPreference mStatusBarBatteryShowPercent;
     private ListPreference mNetTrafficState;
@@ -95,6 +111,9 @@ public class StatusBarSettings extends SettingsPreferenceFragment
 
         mStatusBarClock = (ListPreference) findPreference(STATUS_BAR_CLOCK_STYLE);
         mStatusBarAmPm = (ListPreference) findPreference(STATUS_BAR_AM_PM);
+        mStatusBarDate = (ListPreference) findPreference(STATUS_BAR_DATE);
+        mStatusBarDateStyle = (ListPreference) findPreference(STATUS_BAR_DATE_STYLE);
+        mStatusBarDateFormat = (ListPreference) findPreference(STATUS_BAR_DATE_FORMAT);
         mStatusBarBattery = (ListPreference) findPreference(STATUS_BAR_BATTERY_STYLE);
         mStatusBarBatteryShowPercent =
                 (ListPreference) findPreference(STATUS_BAR_SHOW_BATTERY_PERCENT);
@@ -116,6 +135,26 @@ public class StatusBarSettings extends SettingsPreferenceFragment
             mStatusBarAmPm.setSummary(mStatusBarAmPm.getEntry());
             mStatusBarAmPm.setOnPreferenceChangeListener(this);
         }
+
+        int showDate = Settings.System.getInt(resolver,
+                Settings.System.STATUS_BAR_DATE, 0);
+        mStatusBarDate.setValue(String.valueOf(showDate));
+        mStatusBarDate.setSummary(mStatusBarDate.getEntry());
+        mStatusBarDate.setOnPreferenceChangeListener(this);
+
+        int dateStyle = Settings.System.getInt(resolver,
+                Settings.System.STATUS_BAR_DATE_STYLE, 0);
+        mStatusBarDateStyle.setValue(String.valueOf(dateStyle));
+        mStatusBarDateStyle.setSummary(mStatusBarDateStyle.getEntry());
+        mStatusBarDateStyle.setOnPreferenceChangeListener(this);
+
+        mStatusBarDateFormat.setOnPreferenceChangeListener(this);
+        mStatusBarDateFormat.setSummary(mStatusBarDateFormat.getEntry());
+        if (mStatusBarDateFormat.getValue() == null) {
+            mStatusBarDateFormat.setValue("EEE");
+        }
+
+        parseClockDateFormats();
 
         int batteryStyle = CMSettings.System.getInt(resolver,
                 CMSettings.System.STATUS_BAR_BATTERY_STYLE, 0);
@@ -202,6 +241,7 @@ public class StatusBarSettings extends SettingsPreferenceFragment
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
+        AlertDialog dialog;
         ContentResolver resolver = getActivity().getContentResolver();
         if (preference == mStatusBarClock) {
             int clockStyle = Integer.parseInt((String) newValue);
@@ -216,6 +256,64 @@ public class StatusBarSettings extends SettingsPreferenceFragment
             CMSettings.System.putInt(
                     resolver, CMSettings.System.STATUS_BAR_AM_PM, statusBarAmPm);
             mStatusBarAmPm.setSummary(mStatusBarAmPm.getEntries()[index]);
+            return true;
+        } else if (preference == mStatusBarDate) {
+            int statusBarDate = Integer.valueOf((String) newValue);
+            int index = mStatusBarDate.findIndexOfValue((String) newValue);
+            Settings.System.putInt(
+                    resolver, STATUS_BAR_DATE, statusBarDate);
+            mStatusBarDate.setSummary(mStatusBarDate.getEntries()[index]);
+            return true;
+        } else if (preference == mStatusBarDateStyle) {
+            int statusBarDateStyle = Integer.parseInt((String) newValue);
+            int index = mStatusBarDateStyle.findIndexOfValue((String) newValue);
+            Settings.System.putInt(
+                    resolver, STATUS_BAR_DATE_STYLE, statusBarDateStyle);
+            mStatusBarDateStyle.setSummary(mStatusBarDateStyle.getEntries()[index]);
+            return true;
+        } else if (preference ==  mStatusBarDateFormat) {
+            int index = mStatusBarDateFormat.findIndexOfValue((String) newValue);
+            if (index == CUSTOM_CLOCK_DATE_FORMAT_INDEX) {
+                AlertDialog.Builder alert = new AlertDialog.Builder(getActivity());
+                alert.setTitle(R.string.status_bar_date_string_edittext_title);
+                alert.setMessage(R.string.status_bar_date_string_edittext_summary);
+
+                final EditText input = new EditText(getActivity());
+                String oldText = Settings.System.getString(
+                    getActivity().getContentResolver(),
+                    Settings.System.STATUS_BAR_DATE_FORMAT);
+                if (oldText != null) {
+                    input.setText(oldText);
+                }
+                alert.setView(input);
+
+                alert.setPositiveButton(R.string.menu_save, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialogInterface, int whichButton) {
+                        String value = input.getText().toString();
+                        if (value.equals("")) {
+                            return;
+                        }
+                        Settings.System.putString(getActivity().getContentResolver(),
+                            Settings.System.STATUS_BAR_DATE_FORMAT, value);
+
+                        return;
+                    }
+                });
+
+                alert.setNegativeButton(R.string.menu_cancel,
+                    new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialogInterface, int which) {
+                        return;
+                    }
+                });
+                dialog = alert.create();
+                dialog.show();
+            } else {
+                if ((String) newValue != null) {
+                    Settings.System.putString(getActivity().getContentResolver(),
+                        Settings.System.STATUS_BAR_DATE_FORMAT, (String) newValue);
+                }
+            }
             return true;
         } else if (preference == mStatusBarBattery) {
             int batteryStyle = Integer.valueOf((String) newValue);
@@ -284,39 +382,48 @@ public class StatusBarSettings extends SettingsPreferenceFragment
         }
     }
 
-    private void loadResources() {
-        Resources resources = getActivity().getResources();
-        MASK_UP = resources.getInteger(R.integer.maskUp);
-        MASK_DOWN = resources.getInteger(R.integer.maskDown);
-        MASK_UNIT = resources.getInteger(R.integer.maskUnit);
-        MASK_PERIOD = resources.getInteger(R.integer.maskPeriod);
-    }
-
-    // intMask should only have the desired bit(s) set
-    private int setBit(int intNumber, int intMask, boolean blnState) {
-        if (blnState) {
-            return (intNumber | intMask);
-        }
-        return (intNumber & ~intMask);
-    }
-
-    private boolean getBit(int intNumber, int intMask) {
-        return (intNumber & intMask) == intMask;
-        
-       }
-       
-    private void updatePulldownSummary(int value) {
-        Resources res = getResources();
-
-        if (value == 0) {
-            // quick pulldown deactivated
-            mQuickPulldown.setSummary(res.getString(R.string.status_bar_quick_qs_pulldown_off));
+    private void enableStatusBarClockDependents() {
+        int clockStyle = CMSettings.System.getInt(getActivity()
+                .getContentResolver(), CMSettings.System.STATUS_BAR_CLOCK, 1);
+        if (clockStyle == 0) {
+            mStatusBarDate.setEnabled(false);
+            mStatusBarDateStyle.setEnabled(false);
+            mStatusBarDateFormat.setEnabled(false);
         } else {
-            String direction = res.getString(value == 2
-                    ? R.string.status_bar_quick_qs_pulldown_summary_left
-                    : R.string.status_bar_quick_qs_pulldown_summary_right);
-            mQuickPulldown.setSummary(res.getString(R.string.status_bar_quick_qs_pulldown_summary, direction));
+            mStatusBarDate.setEnabled(true);
+            mStatusBarDateStyle.setEnabled(true);
+            mStatusBarDateFormat.setEnabled(true);
         }
+    }
+
+    private void parseClockDateFormats() {
+        // Parse and repopulate mClockDateFormats's entries based on current date.
+        String[] dateEntries = getResources().getStringArray(R.array.status_bar_date_format_entries_values);
+        CharSequence parsedDateEntries[];
+        parsedDateEntries = new String[dateEntries.length];
+        Date now = new Date();
+
+        int lastEntry = dateEntries.length - 1;
+        int dateFormat = Settings.System.getInt(getActivity()
+                .getContentResolver(), Settings.System.STATUS_BAR_DATE_STYLE, 0);
+        for (int i = 0; i < dateEntries.length; i++) {
+            if (i == lastEntry) {
+                parsedDateEntries[i] = dateEntries[i];
+            } else {
+                String newDate;
+                CharSequence dateString = DateFormat.format(dateEntries[i], now);
+                if (dateFormat == CLOCK_DATE_STYLE_LOWERCASE) {
+                    newDate = dateString.toString().toLowerCase();
+                } else if (dateFormat == CLOCK_DATE_STYLE_UPPERCASE) {
+                    newDate = dateString.toString().toUpperCase();
+                } else {
+                    newDate = dateString.toString();
+                }
+
+                parsedDateEntries[i] = newDate;
+            }
+        }
+        mStatusBarDateFormat.setEntries(parsedDateEntries);
     }
 
     public static final Indexable.SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =


### PR DESCRIPTION
- Date style
- Date format
- 0 - Regular style
- 1 - Lowercase
- 2 - Uppercase

Conflicts:
    res/values/rr_arrays.xml
    res/values/rr_strings.xml

Conflicts:
    res/values/cr_arrays.xml
    res/values/cr_strings.xml
    src/com/android/settings/cyanogenmod/StatusBarSettings.java

Change-Id: I734a0ddef05c1662d7e2d0d899551d2df3141367
